### PR TITLE
Indexer issue

### DIFF
--- a/Expando/Expando.cs
+++ b/Expando/Expando.cs
@@ -378,7 +378,13 @@ namespace Westwind.Utilities.Dynamic
             if (includeInstanceProperties && Instance != null)
             {
                 foreach (var prop in this.InstancePropertyInfo)
+                {
+                    if (prop.Name=="Item")
+                    {
+                        continue;
+                    }
                     yield return new KeyValuePair<string, object>(prop.Name, prop.GetValue(Instance, null));
+                }
             }
 
             foreach (var key in this.Properties.Keys)

--- a/Expando/Expando.cs
+++ b/Expando/Expando.cs
@@ -359,7 +359,7 @@ namespace Westwind.Utilities.Dynamic
                 }
 
                 // check instance for existance of type first
-                var miArray = InstanceType.GetMember(key, BindingFlags.Public | BindingFlags.GetProperty);
+                var miArray = InstanceType.GetMember(key, BindingFlags.Public | BindingFlags.GetProperty|BindingFlags.Instance);
                 if (miArray != null && miArray.Length > 0)
                     SetProperty(Instance, key, value);
                 else

--- a/Expando/Expando.csproj
+++ b/Expando/Expando.csproj
@@ -31,6 +31,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -45,6 +49,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyBag.cs" />
     <Compile Include="Utilities\SerializationUtils.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Expando/packages.config
+++ b/Expando/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net4" />
-  <package id="NUnit" version="3.0.0" targetFramework="net4" />
 </packages>

--- a/ExpandoTests/ExpandoNunit.cs
+++ b/ExpandoTests/ExpandoNunit.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Westwind.Utilities.Dynamic;
+
+namespace ExpandoTests
+{
+
+
+    public class ObjWithProp : Expando
+    {
+        public string SomeProp { get; set; }
+    }
+
+    [TestFixture]
+    class ExpandoNunit
+    {
+            [Test]
+            public void Given_Porp_When_SetWithIndex_Then_PropsValue()
+            {
+                //arrange
+                ObjWithProp obj = new ObjWithProp();
+                //act
+                obj.SomeProp = "value1";
+                obj["SomeProp"] = "value2";
+                //assert
+                Assert.AreEqual("value2", obj.SomeProp);
+
+            }
+        }
+    
+}

--- a/ExpandoTests/ExpandoNunit.cs
+++ b/ExpandoTests/ExpandoNunit.cs
@@ -12,6 +12,24 @@ namespace ExpandoTests
     public class ObjWithProp : Expando
     {
         public string SomeProp { get; set; }
+        public object this[int key]
+        {
+            get
+            {
+                string property = this.GetProperties()[key];
+                return this[property];
+            }
+            set
+            {
+                string property = GetProperties()[key];
+                this[property] = value;
+            }
+        }
+         public List<string> GetProperties()
+        {
+            List<string> properties = base.GetProperties(true).Select(x => x.Key).ToList();
+            return properties;
+        }
     }
 
     [TestFixture]
@@ -29,6 +47,21 @@ namespace ExpandoTests
                 Assert.AreEqual("value2", obj.SomeProp);
 
             }
+
+        [Test]
+        public void Given_Obj_When_GetPropsWithInstance_Then_GetPropsWithoutItemProp()
+        {
+            //arrange
+
+            ObjWithProp obj = new ObjWithProp();
+            obj.SomeProp = "value1";
+            //act
+            List<string> properties = obj.GetProperties(true).Select(x=>x.Key).ToList();
+            //assert
+            CollectionAssert.DoesNotContain(properties,"Item");
+
+        }
+
         }
     
 }

--- a/ExpandoTests/ExpandoTests.csproj
+++ b/ExpandoTests/ExpandoTests.csproj
@@ -35,8 +35,13 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.0.5797.27539, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.0\lib\net40\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -52,6 +57,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExpandoNunit.cs" />
     <Compile Include="SerializationUtils.cs" />
     <Compile Include="ExpandoTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
if the inhereting object has an indexer , than the GetProperties Tries to get it as a Property and fails
So the The change is just not to allow the Indexer Property to return as property